### PR TITLE
Make alpha channel useable

### DIFF
--- a/include/_2RealGStreamerWrapper.h
+++ b/include/_2RealGStreamerWrapper.h
@@ -195,7 +195,7 @@ namespace _2RealGStreamerWrapper
 			audio codec of the operating system and play the sound synchronized to the video (or just play the sound if there is no video
 			data)
 		*/
-		bool					open( std::string strFilename, bool bGenerateVideoBuffer = true, bool bGenerateAudioBuffer = true );
+		bool					open( std::string strFilename, bool bGenerateVideoBuffer = true, bool bGenerateAudioBuffer = true, unsigned int iBytesPerPixel = 24  );
 
 		/*
 			Closes the file and frees allocated memory for both video and audio buffers as well as various GStreamer references

--- a/include/_2RealGStreamerWrapper.h
+++ b/include/_2RealGStreamerWrapper.h
@@ -340,6 +340,11 @@ namespace _2RealGStreamerWrapper
 		*/
 		unsigned char*			getVideo();
 
+    /*
+      Returns the size of the current Video Buffer
+    */
+    gint64        getVideoBufferSize();
+
 		/*
 			Returns the index of the current video stream
 		*/
@@ -665,6 +670,7 @@ namespace _2RealGStreamerWrapper
 		gint64					m_iNumberOfFrames; /* Total number of frames in media file */
 		gint64					m_iCurrentTimeInNs; /* Current time position in nanoseconds */
 		gint64					m_iDurationInNs; /* Duration of media file in nanoseconds */
+    gint64          m_iVideoBufferSize;
 
 		PlayState				m_CurrentPlayState; /* The current state of the wrapper */
 		PlayDirection			m_PlayDirection; /* The current playback direction */

--- a/src/_2RealGStreamerWrapper.cpp
+++ b/src/_2RealGStreamerWrapper.cpp
@@ -178,6 +178,7 @@ bool GStreamerWrapper::open( std::string strFilename, bool bGenerateVideoBuffer,
 	m_fFps = 0;
 	m_dDurationInMs = 0;
 	m_iNumberOfFrames = 0;
+  m_iVideoBufferSize = 0;
 
 	m_fVolume = 1.0f;
 	m_fSpeed = 1.0f;
@@ -557,6 +558,11 @@ unsigned char* GStreamerWrapper::getVideo()
 
 	m_bIsNewVideoFrame = false;
 	return m_cVideoBuffer;
+}
+
+gint64 GStreamerWrapper::getVideoBufferSize()
+{
+	return m_iVideoBufferSize;
 }
 
 int GStreamerWrapper::getCurrentVideoStream()
@@ -980,8 +986,11 @@ void GStreamerWrapper::newVideoSinkPrerollCallback( GstBuffer* videoSinkBuffer )
 		m_cVideoBuffer = new unsigned char[videoBufferSize];
 	}
 
+  // Make the video buffer size available
+  m_iVideoBufferSize = GST_BUFFER_SIZE( videoSinkBuffer );
+
 	// Copy the video appsink buffer data to our unsigned char array
-	memcpy( (unsigned char *)m_cVideoBuffer, (unsigned char *)GST_BUFFER_DATA( videoSinkBuffer ), GST_BUFFER_SIZE( videoSinkBuffer ) );
+	memcpy( (unsigned char *)m_cVideoBuffer, (unsigned char *)GST_BUFFER_DATA( videoSinkBuffer ), m_iVideoBufferSize );
 }
 
 void GStreamerWrapper::newVideoSinkBufferCallback( GstBuffer* videoSinkBuffer )

--- a/src/_2RealGStreamerWrapper.cpp
+++ b/src/_2RealGStreamerWrapper.cpp
@@ -152,7 +152,7 @@ GStreamerWrapper::~GStreamerWrapper()
 	close();
 }
 
-bool GStreamerWrapper::open( std::string strFilename, bool bGenerateVideoBuffer, bool bGenerateAudioBuffer )
+bool GStreamerWrapper::open( std::string strFilename, bool bGenerateVideoBuffer, bool bGenerateAudioBuffer, unsigned int iBytesPerPixel )
 {
 	if( m_bFileIsOpen )
 	{
@@ -221,8 +221,10 @@ bool GStreamerWrapper::open( std::string strFilename, bool bGenerateVideoBuffer,
 
 		// Set some fix caps for the video sink
 		// It would seem that GStreamer then tries to transform any incoming video stream according to these caps
+		
+
 		GstCaps* caps = gst_caps_new_simple( "video/x-raw-rgb",
-			"bpp", G_TYPE_INT, 24,
+			"bpp", G_TYPE_INT, iBytesPerPixel,
 			"depth", G_TYPE_INT, 24,
 			"endianness",G_TYPE_INT,4321,
 			"red_mask",G_TYPE_INT,0xff0000,


### PR DESCRIPTION
Hey,

the bpp was hardcoded to 24. I added the possibility to set them with open(...), still defaults to 24 then. I also added a getVideoBufferSize() function, which makes it easier to calculate the number of channels. 
